### PR TITLE
Connect watchlist to live quotes

### DIFF
--- a/src/lib/services/market-data-service.ts
+++ b/src/lib/services/market-data-service.ts
@@ -16,6 +16,8 @@ interface UnifiedStockData {
   marketCap?: number;
   beta?: number;
   peRatio?: number;
+  week52High?: number;
+  week52Low?: number;
   lastUpdated: Date;
   
   // Fundamental metrics (from Alpha Vantage)
@@ -143,6 +145,8 @@ class MarketDataService {
       priceChangePercent: quote.change_percentage,
       volume: quote.volume,
       avgVolume: quote.average_volume,
+      week52High: quote.week_52_high,
+      week52Low: quote.week_52_low,
       beta: fundamentals?.beta,
       peRatio: fundamentals?.peRatio,
       lastUpdated: new Date(),


### PR DESCRIPTION
## Summary
- fetch live quotes when adding watchlist items and show 52-week range
- expose 52-week high/low from market data service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors across repo)*
- `npm run build` *(fails: could not fetch Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_689a50c170a48330aa22f4f222374ecf