### PR TITLE
Load all IPS factors from database

### DIFF
--- a/src/app/ips/page.tsx
+++ b/src/app/ips/page.tsx
@@ -113,12 +113,16 @@ export default function IPSPage() {
 
   // Load factor definitions when strategies are selected
   useEffect(() => {
-    if (state.selectedStrategies.length > 0) {
-      const factors = ipsDataService.getFactorsForStrategies(state.selectedStrategies);
-      setFactorDefinitions(factors);
-    } else {
-      setFactorDefinitions(null);
-    }
+    const loadFactors = async () => {
+      if (state.selectedStrategies.length > 0) {
+        const factors = await ipsDataService.getFactorsForStrategies(state.selectedStrategies);
+        setFactorDefinitions(factors);
+      } else {
+        setFactorDefinitions(null);
+      }
+    };
+
+    loadFactors();
   }, [state.selectedStrategies]);
 
   // Navigation handlers


### PR DESCRIPTION
## Summary
- fetch factor definitions from Supabase instead of static shortlist so the IPS builder shows every quantitative, qualitative, and options factor
- load factor definitions asynchronously when strategies are chosen on the IPS page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unexpected any and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_689b884fdb3483309fc1a38c54a92c3e