### PR TITLE
feat: replace alerts with toast notifications for IPS changes

### DIFF
--- a/src/app/ips/page.tsx
+++ b/src/app/ips/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Progress } from "@/components/ui/progress";
+import { toast } from "sonner";
 import {
   FileText,
   Settings,
@@ -191,7 +192,7 @@ export default function IPSPage() {
   // Save new IPS (quick create)
   async function saveIPS() {
     if (!name.trim()) {
-      alert("Please enter an IPS name");
+      toast.error("Please enter an IPS name");
       return;
     }
 
@@ -217,15 +218,21 @@ export default function IPSPage() {
 
       if (error) {
         console.error("Error inserting IPS:", error);
-        alert("Failed to save IPS: " + error.message);
+        toast.error("Failed to save IPS: " + error.message);
       } else {
         setName("");
         setDescription("");
         await fetchIPS();
+        const inserted = Array.isArray(data) && data[0];
+        if (inserted?.name) {
+          toast.success(`IPS "${inserted.name}" created`);
+        } else {
+          toast.success("IPS created");
+        }
       }
     } catch (err) {
       console.error("Unexpected error saving IPS:", err);
-      alert("Unexpected error saving IPS");
+      toast.error("Unexpected error saving IPS");
     }
   }
 
@@ -240,13 +247,14 @@ export default function IPSPage() {
 
       if (error) {
         console.error("Error deleting IPS:", error);
-        alert("Failed to delete IPS: " + error.message);
+        toast.error("Failed to delete IPS: " + error.message);
       } else {
         await fetchIPS();
+        toast.success("IPS deleted");
       }
     } catch (err) {
       console.error("Unexpected error deleting IPS:", err);
-      alert("Unexpected error deleting IPS");
+      toast.error("Unexpected error deleting IPS");
     }
   }
 
@@ -383,9 +391,10 @@ export default function IPSPage() {
         currentIPSId: null,
         isLoading: false,
       });
+      toast.success(`IPS "${ipsData.name}" saved`);
     } catch (error: any) {
       console.error("Error saving IPS:", error);
-      alert("Error saving IPS: " + error.message);
+      toast.error("Error saving IPS: " + error.message);
     } finally {
       setCreating(false);
     }

--- a/src/components/ips/ips-summary.tsx
+++ b/src/components/ips/ips-summary.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
 import { 
   ArrowLeft, 
   Save, 
@@ -63,7 +64,7 @@ export function IPSSummary({
 
   const handleSave = async () => {
     if (!ipsName.trim()) {
-      alert('Please enter an IPS name');
+      toast.error('Please enter an IPS name');
       return;
     }
 


### PR DESCRIPTION
## Summary
- replace alert dialogs with animated toast notifications when creating or deleting an IPS
- add toast-based validation for missing IPS names in summary form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689e3808a160833099c87f6920d0a0ab