### PR TITLE
fix: ensure trades page shows active ips

### DIFF
--- a/src/app/trades/page.tsx
+++ b/src/app/trades/page.tsx
@@ -242,7 +242,7 @@ export default function TradesPage() {
       try {
         setIsLoading(true);
         const userIPSs = await ipsDataService.getAllUserIPSs(userId);
-        const activeOnly = userIPSs.filter((ips) => ips.is_active);
+        const activeOnly = userIPSs.filter((ips) => ips.is_active === true);
         setActiveIPSs(activeOnly);
       } catch (e) {
         console.error("Error loading IPS data:", e);

--- a/src/lib/services/ips-data-service.ts
+++ b/src/lib/services/ips-data-service.ts
@@ -228,6 +228,16 @@ const ALL_FACTORS = [
   ...OPTIONS_FACTORS
 ];
 
+function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    return v === 'true' || v === 't' || v === '1' || v === 'yes';
+  }
+  return false;
+}
+
 class IPSDataService {
   // Store IPS configurations in memory (replace with database in production)
   private ipsConfigurations: Map<string, IPSConfiguration[]> = new Map();
@@ -316,12 +326,7 @@ class IPSDataService {
                   }
                 })()
               : [],
-            is_active:
-              typeof r?.is_active === 'boolean'
-                ? r.is_active
-                : r?.is_active != null
-                ? Boolean(r.is_active)
-                : false,
+            is_active: toBoolean(r?.is_active),
             // FIX: Add the missing required properties
             created_at: String(r?.created_at ?? new Date().toISOString()),
             total_factors: Number(r?.total_factors ?? 0),


### PR DESCRIPTION
## Summary
- parse `is_active` values from Supabase reliably with `toBoolean`
- filter IPS configurations strictly by active status on trades page

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_689e463d52808330916a32d9ae1bda66