### PR TITLE
Migrate IPS tables and env variables

### DIFF
--- a/src/app/api/trades/factors/route.ts
+++ b/src/app/api/trades/factors/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
 
     // Get IPS configuration from database
     const { data: ips, error: ipsError } = await supabase
-      .from('investment_performance_systems')
+      .from('ips_configurations')
       .select('*')
       .eq('id', ipsId)
       .single();
@@ -271,10 +271,10 @@ export async function POST(request: NextRequest) {
       throw new Error(`Failed to save factor: ${insertError.message}`);
     }
 
-    // If tradeId provided, also save to trade_factors
+    // If tradeId provided, also save to trade_evaluations
     if (tradeId) {
       const { error: tradeFactorError } = await supabase
-        .from('trade_factors')
+        .from('trade_evaluations')
         .upsert({
           trade_id: tradeId,
           factor_name: factorName,

--- a/src/app/api/trades/score/route.ts
+++ b/src/app/api/trades/score/route.ts
@@ -200,7 +200,7 @@ export async function POST(request: NextRequest) {
     const targetsMetCount = factorScores.filter(f => f.targetMet).length;
     const targetPercentage = factorScores.length > 0 ? (targetsMetCount / factorScores.length) * 100 : 0;
 
-    // Save score calculation to database
+    // Save trade evaluation to database
     const scoreData = {
       ips_id: ipsId,
       trade_id: tradeId || null,
@@ -218,7 +218,7 @@ export async function POST(request: NextRequest) {
     };
 
     const { data: savedScore, error: scoreError } = await supabase
-      .from('ips_score_calculations')
+      .from('trade_evaluations')
       .insert(scoreData)
       .select()
       .single();
@@ -229,7 +229,7 @@ export async function POST(request: NextRequest) {
 
     // Also save individual factor scores
     const factorScoreInserts = factorScores.map(fs => ({
-      ips_score_calculation_id: savedScore?.id,
+      trade_evaluation_id: savedScore?.id,
       factor_name: fs.factorName,
       factor_value: fs.value,
       weight: fs.weight,

--- a/src/lib/services/market-data-service.ts
+++ b/src/lib/services/market-data-service.ts
@@ -97,8 +97,8 @@ class MarketDataService {
   private alphaVantage = getAlphaVantageClient();
   private tradier = getTradierClient();
   private supabase = createClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 
   // Cache to avoid duplicate API calls

--- a/test-ips-creation.ts
+++ b/test-ips-creation.ts
@@ -9,12 +9,12 @@ async function testIPSCreation() {
   
   // Check environment variables
   console.log('1. Checking environment variables...');
-  const url = process.env.SUPABASE_URL;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   
   if (!url || !key) {
     console.error('❌ Missing environment variables!');
-    console.log('   SUPABASE_URL:', url ? '✓ Set' : '✗ Missing');
+    console.log('   NEXT_PUBLIC_SUPABASE_URL:', url ? '✓ Set' : '✗ Missing');
     console.log('   SUPABASE_SERVICE_ROLE_KEY:', key ? '✓ Set' : '✗ Missing');
     process.exit(1);
   }
@@ -77,11 +77,14 @@ async function testIPSCreation() {
     }
     
     // Test 3: Query the view
-    console.log('\n5. Testing view query (ips_with_factors)...');
+    console.log('\n5. Testing view query (ips_configurations)...');
     const { data: viewData, error: viewError } = await supabase
-      .from('ips_with_factors')
-      .select('*')
-      .eq('ips_id', data.id);
+      .from('ips_configurations')
+      .select(`
+        *,
+        ips_factors (*)
+      `)
+      .eq('id', data.id);
     
     if (viewError) {
       console.error('❌ Failed to query view:', viewError.message);

--- a/test-supabase-connection.ts
+++ b/test-supabase-connection.ts
@@ -6,11 +6,11 @@ console.log('=== Supabase Connection Test ===');
 
 // 1. Check environment variables
 console.log('1. Checking environment variables...');
-const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl) {
-  console.log('❌ SUPABASE_URL is not set in environment variables');
+  console.log('❌ NEXT_PUBLIC_SUPABASE_URL is not set in environment variables');
   process.exit(1);
 }
 
@@ -20,7 +20,7 @@ if (!supabaseKey) {
 }
 
 console.log('✅ Environment variables are set');
-console.log(`   SUPABASE_URL: ${supabaseUrl.slice(0, 30)}...`);
+console.log(`   NEXT_PUBLIC_SUPABASE_URL: ${supabaseUrl.slice(0, 30)}...`);
 console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${supabaseKey.slice(0, 30)}...`);
 
 // 2. Create Supabase client


### PR DESCRIPTION
## Summary
- replace legacy IPS table references with `ips_configurations` and store trade factors in `trade_evaluations`
- write trade scores to new `trade_evaluations` table and update id reference
- switch Supabase client setup to use public URL and anon key
- update test scripts for new env variables and IPS query structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_689eac303e648330941812c42f6f4587