### PR TITLE
Fix IPS editing to preload factor selections

### DIFF
--- a/src/app/ips/page.tsx
+++ b/src/app/ips/page.tsx
@@ -471,25 +471,6 @@ export default function IPSPage() {
   };
 
   const handleEditIPS = async (ipsId: string) => {
-  const handleViewIPS = async (ipsId: string) => {
-
-    const ips = allIPSs.find((i) => i.id === ipsId);
-    if (!ips) return;
-
-    const { data: factors, error } = await supabase
-      .from("ips_factors")
-      .select("*")
-      .eq("ips_id", ipsId);
-
-    if (error) {
-      console.error("Error loading IPS factors:", error);
-      return;
-    }
-
-    setDetailsDialog({ isOpen: true, ips, factors: factors || [] });
-  };
-
-  const handleEditIPS = async (ipsId: string) => {
     const ips = allIPSs.find((i) => i.id === ipsId);
     if (!ips) return;
 
@@ -529,10 +510,20 @@ export default function IPSPage() {
       };
     });
 
+    // Load factor definitions for the IPS strategies so the selector renders
+    const strategies = (ips as any).strategies || [];
+    try {
+      const defs = ipsDataService.getFactorsForStrategies(strategies);
+      setFactorDefinitions(defs);
+    } catch (e) {
+      console.error("Error loading factor definitions:", e);
+      setFactorDefinitions(null as any);
+    }
+
     setState((prev) => ({
       ...prev,
       step: "selection",
-      selectedStrategies: (ips as any).strategies || [],
+      selectedStrategies: strategies,
       selectedFactors: selected,
       factorConfigurations: configurations,
       currentIPSId: ipsId,
@@ -553,7 +544,40 @@ export default function IPSPage() {
   };
 
   const handleFactorSelection = (selectedFactors: Set<string>) => {
-    setState((prev) => ({ ...prev, selectedFactors }));
+    setState((prev) => {
+      const allDefs = ipsDataService.getAllFactors();
+      const newConfigs = { ...prev.factorConfigurations };
+
+      // Add default configs for newly selected factors
+      selectedFactors.forEach((name) => {
+        if (!newConfigs[name]) {
+          const info =
+            allDefs.find((df: any) => df.name === name) ||
+            ({ id: name, type: "quantitative", category: "Unknown" } as any);
+          newConfigs[name] = {
+            weight: 5,
+            enabled: true,
+            targetType: info.type === "qualitative" ? "rating" : "numeric",
+            targetValue: info.type === "qualitative" ? 4 : "",
+            targetOperator: "gte",
+            targetValueMax: "",
+            preferenceDirection: "higher",
+            factorId: info.id,
+            type: info.type,
+            category: info.category,
+          } as any;
+        }
+      });
+
+      // Remove configurations for factors that were deselected
+      Object.keys(newConfigs).forEach((name) => {
+        if (!selectedFactors.has(name)) {
+          delete newConfigs[name];
+        }
+      });
+
+      return { ...prev, selectedFactors, factorConfigurations: newConfigs };
+    });
   };
 
   const handleFactorConfiguration = (configurations: Record<string, any>) => {


### PR DESCRIPTION
## Summary
- preload factor definitions and configurations when editing an IPS
- create default configurations for newly selected factors and remove deselected ones

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2b89f98c83309349550dfa5564a5