### PR TITLE
Add global date and number formatting utilities

### DIFF
--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import { BookOpen, Plus, Calendar, Edit, Trash2 } from 'lucide-react'
+import { formatDate } from '@/lib/utils'
 
 interface JournalEntry {
   id: string
@@ -74,7 +75,7 @@ export default function JournalPage() {
     const endDate = new Date(date)
     endDate.setDate(date.getDate() + 6)
     
-    return `${date.toLocaleDateString()} - ${endDate.toLocaleDateString()}`
+    return `${formatDate(date)} - ${formatDate(endDate)}`
   }
 
   return (
@@ -193,7 +194,7 @@ export default function JournalPage() {
                         {getWeekDateRange(entry.weekOf)}
                       </span>
                       <Badge variant="outline">
-                        {new Date(entry.createdAt).toLocaleDateString()}
+                        {formatDate(entry.createdAt)}
                       </Badge>
                     </div>
                   </div>

--- a/src/components/dashboard/market-overview.tsx
+++ b/src/components/dashboard/market-overview.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { AlertCircle, TrendingUp, TrendingDown, RefreshCw, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { formatNumber } from '@/lib/utils'
 
 interface MarketIndex {
   symbol: string
@@ -75,9 +76,9 @@ export function MarketOverview() {
         return {
           symbol: d.symbol,
           name: getIndexName(d.symbol),
-          price: `$${Number(d.currentPrice).toFixed(2)}`,
-          change: `${isPositive ? '+' : ''}$${Math.abs(Number(d.priceChange)).toFixed(2)}`,
-          changePercent: `${isPositive ? '+' : ''}${Number(d.priceChangePercent).toFixed(2)}%`,
+          price: `$${formatNumber(Number(d.currentPrice))}`,
+          change: `${isPositive ? '+' : ''}$${formatNumber(Math.abs(Number(d.priceChange)))}`,
+          changePercent: `${isPositive ? '+' : ''}${formatNumber(Number(d.priceChangePercent))}%`,
           isPositive,
           lastUpdated: new Date(d.lastUpdated).toISOString(),
         }

--- a/src/components/dashboard/trading-stats.tsx
+++ b/src/components/dashboard/trading-stats.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Activity, DollarSign, TrendingUp } from 'lucide-react'
+import { formatNumber } from '@/lib/utils'
 
 interface TradingStatsProps {
   activeTrades: number
@@ -67,7 +68,7 @@ export function TradingStats({
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
-            {winRate !== null ? `${winRate.toFixed(1)}%` : '--'}
+            {winRate !== null ? `${formatNumber(winRate)}%` : '--'}
           </div>
           <p className="text-xs text-muted-foreground">
             {winRate === null ? 'No completed trades' : 'Historical performance'}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,32 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { format } from "date-fns"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+/**
+ * Format a date into a user-friendly string like `Sep 4, 2025`.
+ */
+export function formatDate(value: Date | string | number): string {
+  const date = new Date(value)
+  return format(date, "MMM d, yyyy")
+}
+
+/**
+ * Format a time value into a user-friendly string like `9:00 AM`.
+ */
+export function formatTime(value: Date | string | number): string {
+  const date = new Date(value)
+  return format(date, "p")
+}
+
+/**
+ * Round a number to the nearest tenth.
+ */
+export function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined || isNaN(value)) return ""
+  const rounded = Math.round(value * 10) / 10
+  return rounded.toFixed(1)
 }


### PR DESCRIPTION
## Summary
- add `formatDate`, `formatTime`, and `formatNumber` helpers
- use new helpers to show friendlier dates in journal and round stats to tenths
- simplify market overview prices to one decimal place

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02e157548330b632b29d81dbd6ad