### PR TITLE
Round IPS score to one decimal

### DIFF
--- a/src/components/dashboard/excel-style-trades-dashboard.tsx
+++ b/src/components/dashboard/excel-style-trades-dashboard.tsx
@@ -286,7 +286,7 @@ export default function ExcelStyleTradesDashboard() {
       case 'dateClosed':
         return formatDate(value)
       case 'ipsScore':
-        return typeof value === 'number' ? `${Math.round(value)}/100` : '-'
+        return typeof value === 'number' ? `${value.toFixed(1)}/100` : '-'
       case 'status': {
         const tag = String(value).toUpperCase()
         const cls = tag === 'GOOD' ? 'bg-green-100 text-green-800 border-green-200' : tag === 'EXIT' ? 'bg-red-100 text-red-800 border-red-200' : 'bg-yellow-100 text-yellow-800 border-yellow-200'

--- a/src/components/dashboard/historic-trades-dashboard.tsx
+++ b/src/components/dashboard/historic-trades-dashboard.tsx
@@ -310,7 +310,7 @@ export default function HistoricTradesDashboard() {
         return value.toFixed(3)
       case 'ipsScore':
       case 'ipsAtClose':
-        return value ? `${value}/100` : '-'
+        return typeof value === 'number' ? `${value.toFixed(1)}/100` : '-'
       default:
         return value
     }


### PR DESCRIPTION
## Summary
- Show IPS scores rounded to one decimal in historic trades dashboard
- Show IPS scores rounded to one decimal in excel-style trades dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in many files)*

------
https://chatgpt.com/codex/tasks/task_e_68bb060f344c8330855925c260e03869